### PR TITLE
allow virtual path to be specified in RepositoriesDirectory

### DIFF
--- a/GitAspx/Lib/AppSettings.cs
+++ b/GitAspx/Lib/AppSettings.cs
@@ -37,6 +37,10 @@ namespace GitAspx.Lib {
 				throw new InvalidOperationException("The 'Repositories' AppSetting has not been initialised.");
 			}
 
+            if (path.StartsWith("~/")){
+                path = System.Web.HttpContext.Current.Server.MapPath(path);
+            }
+
 			if (!Directory.Exists(path)) {
 				throw new DirectoryNotFoundException(
 					string.Format("Could not find the directory '{0}' which is configured as the directory of repositories.", path));


### PR DESCRIPTION
I added code to enable virtual path which i think will really be useful instead of hard coding the directory path.

So now both of this works.

```
<add key="RepositoriesDirectory" value="~/App_Data/gitrepos" />
```

or 

```
<add key="RepositoriesDirectory" value="C:\Repositories" />
```
