### PR TITLE
Explicitly reference 1.0.0.0 of System.Web.WebPages and System.Web.Helpers

### DIFF
--- a/GitAspx/GitAspx.csproj
+++ b/GitAspx/GitAspx.csproj
@@ -78,8 +78,8 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web.Services" />
     <Reference Include="System.EnterpriseServices" />
-    <Reference Include="System.Web.WebPages" />
-    <Reference Include="System.Web.Helpers" />
+    <Reference Include="System.Web.WebPages, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
+    <Reference Include="System.Web.Helpers, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Constants.cs" />


### PR DESCRIPTION
This allows the development machine to install higher versions of MVC framework side-by-side without failing applications targeting old MVC

After installing MVC4, the application fails
